### PR TITLE
Fix ppc vle dwarf

### DIFF
--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DWARFCompilationUnit.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DWARFCompilationUnit.java
@@ -351,8 +351,14 @@ public class DWARFCompilationUnit {
 		DebugInfoEntry parent = null;
 		DebugInfoEntry die;
 		DebugInfoEntry unexpectedTerminator = null;
-		while ((br.getPointerIndex() < getEndOffset()) &&
-			(die = DebugInfoEntry.read(br, this, dwarfProgram.getAttributeFactory())) != null) {
+		while ((br.getPointerIndex() < getEndOffset())) {
+			try {
+				die = DebugInfoEntry.read(br, this, dwarfProgram.getAttributeFactory());
+			}
+			catch (IOException ioe) {
+				Msg.error(null, "Skipping compilation unit " + this);
+				continue;
+			}
 
 			monitor.checkCanceled();
 

--- a/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DWARFCompilationUnit.java
+++ b/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/dwarf4/DWARFCompilationUnit.java
@@ -356,7 +356,12 @@ public class DWARFCompilationUnit {
 				die = DebugInfoEntry.read(br, this, dwarfProgram.getAttributeFactory());
 			}
 			catch (IOException ioe) {
-				Msg.error(null, "Skipping compilation unit " + this);
+				Msg.error(null,
+					"Failed to parse the DW_TAG_compile_unit DIE at the start of compilation unit " +
+						this.compUnitNumber + " at offset " + this.startOffset + " (0x" +
+						Long.toHexString(this.startOffset) + "), skipping entire compilation unit",
+					ioe);
+				br.setPointerIndex(this.getEndOffset());
 				continue;
 			}
 


### PR DESCRIPTION
the ppc vle amp binary has an invalid abbreviation code which causes the dwarf parser to throw an uncaught exception that stops parsing the remaining dwarf information

catch the exception and continue parsing the rest of the dwarf information